### PR TITLE
Move plotting recipes to package extensions (weakdeps)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,26 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[weakdeps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+
+[extensions]
+OpenCALPHADPlotsExt = "Plots"
+OpenCALPHADPythonPlotExt = "PythonPlot"
+OpenCALPHADRecipesBaseExt = "RecipesBase"
 
 [compat]
 DifferentiationInterface = "0.7.14"
 ForwardDiff = "0.10"
 JSON = "1.4.0"
 Optim = "2.0.0"
-Plots = "1.41.4"
+Plots = "1.41"
+PythonPlot = "1"
 RecipesBase = "1"
 StaticArrays = "1"
 julia = "1.9"

--- a/ext/OpenCALPHADPlotsExt.jl
+++ b/ext/OpenCALPHADPlotsExt.jl
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2012-2026 Bo Sundman and OpenCALPHAD contributors
+# Copyright (C) 2026 Hiroharu Sugawara (Julia port)
+# Part of OpenCALPHAD.jl - Plots.jl extension
+
+module OpenCALPHADPlotsExt
+
+using Plots
+import OpenCALPHAD
+using OpenCALPHAD: PhaseDiagramResult, GridScanResult
+
+function OpenCALPHAD.plot_phase_diagram(result::PhaseDiagramResult)
+    Plots.plot(result)
+end
+
+function OpenCALPHAD.plot_gibbs_curve(result::GridScanResult)
+    Plots.plot(result)
+end
+
+end # module

--- a/ext/OpenCALPHADRecipesBaseExt.jl
+++ b/ext/OpenCALPHADRecipesBaseExt.jl
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2012-2026 Bo Sundman and OpenCALPHAD contributors
+# Copyright (C) 2026 Hiroharu Sugawara (Julia port)
+# Part of OpenCALPHAD.jl - RecipesBase extension
+
+module OpenCALPHADRecipesBaseExt
+
+using RecipesBase
+using OpenCALPHAD: GridScanResult, StepResult, PhaseDiagramResult
+using OpenCALPHAD: temperatures, gibbs_energies, phase_fractions
+
+"""
+    @recipe for GridScanResult
+
+Plot Gibbs energy curve G(x) from grid scan result.
+"""
+@recipe function f(result::GridScanResult)
+    xlabel --> "Composition x"
+    ylabel --> "Gibbs Energy G [J/mol]"
+    title --> "Gibbs Energy Curve"
+    legend --> false
+    linewidth --> 2
+
+    result.x_grid, result.G_values
+end
+
+"""
+    @recipe for StepResult
+
+Plot Gibbs energy vs temperature from STEP result.
+"""
+@recipe function f(result::StepResult)
+    xlabel --> "Temperature T [K]"
+    ylabel --> "Gibbs Energy G [J/mol]"
+    title --> "STEP Calculation"
+    legend --> false
+    linewidth --> 2
+
+    temperatures(result), gibbs_energies(result)
+end
+
+"""
+    @recipe for StepResult with :phase_fraction plottype
+
+Plot phase fractions vs temperature.
+Usage: plot(result, plottype=:phase_fraction)
+"""
+@recipe function f(result::StepResult, ::Val{:phase_fraction})
+    xlabel --> "Temperature T [K]"
+    ylabel --> "Phase Fraction"
+    title --> "Phase Fractions vs Temperature"
+    legend --> :topright
+    linewidth --> 2
+    ylims --> (0, 1)
+
+    T = temperatures(result)
+    f1 = phase_fractions(result, 1)
+    f2 = phase_fractions(result, 2)
+
+    @series begin
+        label --> "Phase 1"
+        T, f1
+    end
+
+    @series begin
+        label --> "Phase 2"
+        T, f2
+    end
+end
+
+"""
+    @recipe for PhaseDiagramResult
+
+Plot binary phase diagram (T-x diagram) showing miscibility gap boundaries.
+"""
+@recipe function f(result::PhaseDiagramResult)
+    xlabel --> "Composition x"
+    ylabel --> "Temperature T [K]"
+    title --> "Binary Phase Diagram"
+    legend --> false
+    linewidth --> 2
+
+    # Filter converged points only
+    converged = filter(p -> p.converged, result.points)
+
+    if isempty(converged)
+        # Return empty plot if no converged points
+        return Float64[], Float64[]
+    end
+
+    # Extract data for left and right boundaries
+    T_vals = [p.temperature for p in converged]
+    x1_vals = [p.compositions[1] for p in converged]
+    x2_vals = [p.compositions[2] for p in converged]
+
+    # Create closed boundary curve
+    # Go up left boundary, then down right boundary
+    x_boundary = vcat(x1_vals, reverse(x2_vals))
+    T_boundary = vcat(T_vals, reverse(T_vals))
+
+    # Fill the two-phase region
+    fillrange --> 0
+    fillalpha --> 0.3
+    seriestype --> :path
+
+    x_boundary, T_boundary
+end
+
+end # module

--- a/src/OpenCALPHAD.jl
+++ b/src/OpenCALPHAD.jl
@@ -73,6 +73,7 @@ include("Calculations/phase_field.jl")
 
 # Plotting
 include("Plotting/recipes.jl")
+include("Plotting/fallbacks.jl")
 
 # Exports - Types
 export Element, Phase, Parameter, GFunction, Database, MagneticModel
@@ -126,6 +127,7 @@ export boundaries
 
 # Exports - Plotting
 export plot_phase_diagram, plot_gibbs_curve
+export savefig_publication
 
 # Exports - DSL (Julia function parameters)
 export set_G!, set_L!

--- a/src/Plotting/fallbacks.jl
+++ b/src/Plotting/fallbacks.jl
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2012-2026 Bo Sundman and OpenCALPHAD contributors
+# Copyright (C) 2026 Hiroharu Sugawara (Julia port)
+# Part of OpenCALPHAD.jl - Fallback errors for extension-dependent functions
+
+function savefig_publication(args...; kwargs...)
+    throw(ArgumentError(
+        "savefig_publication requires PythonPlot.jl. Run `using PythonPlot` first."
+    ))
+end

--- a/src/Plotting/recipes.jl
+++ b/src/Plotting/recipes.jl
@@ -2,122 +2,27 @@
 # Copyright (C) 2012-2026 Bo Sundman and OpenCALPHAD contributors
 # Copyright (C) 2026 Hiroharu Sugawara (Julia port)
 # Part of OpenCALPHAD.jl - Plot recipes for result types
-
-using RecipesBase
-
-"""
-    @recipe for GridScanResult
-
-Plot Gibbs energy curve G(x) from grid scan result.
-"""
-@recipe function f(result::GridScanResult)
-    xlabel --> "Composition x"
-    ylabel --> "Gibbs Energy G [J/mol]"
-    title --> "Gibbs Energy Curve"
-    legend --> false
-    linewidth --> 2
-
-    result.x_grid, result.G_values
-end
+#
+# Recipe definitions moved to ext/OpenCALPHADRecipesBaseExt.jl
+# Convenience functions implemented in ext/OpenCALPHADPlotsExt.jl
 
 """
-    @recipe for StepResult
+    plot_phase_diagram(result::PhaseDiagramResult)
 
-Plot Gibbs energy vs temperature from STEP result.
+Plot a binary phase diagram. Requires `using Plots`.
 """
-@recipe function f(result::StepResult)
-    xlabel --> "Temperature T [K]"
-    ylabel --> "Gibbs Energy G [J/mol]"
-    title --> "STEP Calculation"
-    legend --> false
-    linewidth --> 2
-
-    temperatures(result), gibbs_energies(result)
-end
+function plot_phase_diagram end
 
 """
-    @recipe for StepResult with :phase_fraction plottype
+    plot_gibbs_curve(result::GridScanResult)
 
-Plot phase fractions vs temperature.
-Usage: plot(result, plottype=:phase_fraction)
+Plot a Gibbs energy curve. Requires `using Plots`.
 """
-@recipe function f(result::StepResult, ::Val{:phase_fraction})
-    xlabel --> "Temperature T [K]"
-    ylabel --> "Phase Fraction"
-    title --> "Phase Fractions vs Temperature"
-    legend --> :topright
-    linewidth --> 2
-    ylims --> (0, 1)
-
-    T = temperatures(result)
-    f1 = phase_fractions(result, 1)
-    f2 = phase_fractions(result, 2)
-
-    @series begin
-        label --> "Phase 1"
-        T, f1
-    end
-
-    @series begin
-        label --> "Phase 2"
-        T, f2
-    end
-end
+function plot_gibbs_curve end
 
 """
-    @recipe for PhaseDiagramResult
+    savefig_publication(result, filename; kwargs...)
 
-Plot binary phase diagram (T-x diagram) showing miscibility gap boundaries.
+Save a publication-quality figure. Requires `using PythonPlot`.
 """
-@recipe function f(result::PhaseDiagramResult)
-    xlabel --> "Composition x"
-    ylabel --> "Temperature T [K]"
-    title --> "Binary Phase Diagram"
-    legend --> false
-    linewidth --> 2
-
-    # Filter converged points only
-    converged = filter(p -> p.converged, result.points)
-
-    if isempty(converged)
-        # Return empty plot if no converged points
-        return Float64[], Float64[]
-    end
-
-    # Extract data for left and right boundaries
-    T_vals = [p.temperature for p in converged]
-    x1_vals = [p.compositions[1] for p in converged]
-    x2_vals = [p.compositions[2] for p in converged]
-
-    # Create closed boundary curve
-    # Go up left boundary, then down right boundary
-    x_boundary = vcat(x1_vals, reverse(x2_vals))
-    T_boundary = vcat(T_vals, reverse(T_vals))
-
-    # Fill the two-phase region
-    fillrange --> 0
-    fillalpha --> 0.3
-    seriestype --> :path
-
-    x_boundary, T_boundary
-end
-
-"""
-    plot_phase_diagram(result::PhaseDiagramResult; kwargs...)
-
-Convenience function to plot a phase diagram with appropriate defaults.
-Returns the plot recipe data for use with Plots.jl.
-"""
-function plot_phase_diagram(result::PhaseDiagramResult)
-    return result
-end
-
-"""
-    plot_gibbs_curve(result::GridScanResult; kwargs...)
-
-Convenience function to plot Gibbs energy curve.
-Returns the plot recipe data for use with Plots.jl.
-"""
-function plot_gibbs_curve(result::GridScanResult)
-    return result
-end
+function savefig_publication end


### PR DESCRIPTION
- Move 4 @recipe definitions to new ext/OpenCALPHADRecipesBaseExt.jl
- Add ext/OpenCALPHADPlotsExt.jl for plot_phase_diagram/plot_gibbs_curve
- Move Plots and RecipesBase from [deps] to [weakdeps]
- Add PythonPlot as weakdep with savefig_publication stub + fallback

All 120 existing tests pass. No user-facing API changes.
Colab demo is unaffected (uses Plots.jl directly).

Closes #16