### PR TITLE
Add Aqua quality assurance and remove unused deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,7 @@ version = "0.1.1"
 [deps]
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
@@ -23,18 +21,21 @@ OpenCALPHADPythonPlotExt = "PythonPlot"
 OpenCALPHADRecipesBaseExt = "RecipesBase"
 
 [compat]
+Aqua = "0.8"
 DifferentiationInterface = "0.7.14"
 ForwardDiff = "0.10"
-JSON = "1.4.0"
-Optim = "2.0.0"
+LinearAlgebra = "1"
 Plots = "1.41"
+Printf = "1"
 PythonPlot = "1"
 RecipesBase = "1"
 StaticArrays = "1"
+Test = "1"
 julia = "1.9"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+OpenCALPHAD = "f22b17f6-ccb9-4067-ab50-5d8cfb3cb77d"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[compat]
+ForwardDiff = "0.10"
+JSON = "1.4.0"
+Optim = "2.0.0"
+Plots = "1.41"
+julia = "1.9"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,12 @@
 using Test
 using OpenCALPHAD
+using Aqua
 
 @testset "OpenCALPHAD.jl" begin
+    @testset "Aqua quality assurance" begin
+        Aqua.test_all(OpenCALPHAD; ambiguities=false)
+    end
+
     @testset "Types" begin
         @testset "Element" begin
             ag = Element("AG", "FCC_A1", 107.8682, 5744.6, 42.551)


### PR DESCRIPTION
## Summary
- Add Aqua.test_all (ambiguities disabled) to the test suite
- Remove JSON and Optim from root `[deps]`; they were only used in examples
- Add `examples/Project.toml` so examples still work via `julia --project=examples`
- Add compat entries for stdlibs (LinearAlgebra, Printf, Test) required by Aqua under Julia 1.11+

## Motivation
- No automated check existed for Project.toml integrity
- Unused hard dependencies were inflating install and precompile time for all users

Closes #22