### PR TITLE
Add 3-layer plotting API (plot_on_axis!, figure_publication); mm axis units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ deps/usr/
 docs/build/
 docs/site/
 
+# CondaPkg-generated environments (PythonPlot/matplotlib via Conda)
+.CondaPkg/
+
 # Paper build artifacts
 paper/paper.pdf
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 OpenCALPHAD = "f22b17f6-ccb9-4067-ab50-5d8cfb3cb77d"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 
 [compat]
 Documenter = "1"
+PythonPlot = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,12 @@
 
 using Documenter
 using OpenCALPHAD
+using PythonPlot                   # loads OpenCALPHADPythonPlotExt so its docstrings render
+PythonPlot.matplotlib.use("Agg")  # headless backend for CI / @example figures
+
+# The PythonPlot extension carries the docstrings for plot_on_axis! /
+# figure_publication / savefig_publication; include it so @docs can render them.
+const OCPythonPlotExt = Base.get_extension(OpenCALPHAD, :OpenCALPHADPythonPlotExt)
 
 makedocs(
     sitename = "OpenCALPHAD.jl",
@@ -12,7 +18,7 @@ makedocs(
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
     ),
-    modules = [OpenCALPHAD],
+    modules = [OpenCALPHAD, OCPythonPlotExt],
     checkdocs = :exports,
     warnonly = [:missing_docs, :cross_references],
     pages = [

--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -6,7 +6,7 @@ OpenCALPHAD.jl provides three plotting paths via package extensions:
 |-----------|---------|---------------|
 | RecipesBaseExt | `using RecipesBase` (or any backend) | `plot(result)` recipes for all result types |
 | PlotsExt | `using Plots` | Convenience functions `plot_gibbs_curve`, `plot_phase_diagram` |
-| PythonPlotExt | `using PythonPlot` | `savefig_publication` for publication-quality static PDF / PNG |
+| PythonPlotExt | `using PythonPlot` | 3-layer API `plot_on_axis!` / `figure_publication` / `savefig_publication` for publication-quality static PDF / PNG |
 
 ---
 
@@ -54,7 +54,7 @@ Plot Gibbs energy G(T) from a STEP calculation.
 ```julia
 db = read_tdb("agcu.TDB")
 fcc = get_phase(db, "FCC_A1")
-result = step_calculation(fcc, db, 300.0, 1400.0, 10.0; x_overall=0.5)
+result = step_temperature(fcc, db, 0.5, 300.0, 1400.0, 10.0)
 
 plot(result)
 ```
@@ -100,7 +100,7 @@ result = map_phase_diagram(fcc, db, 800.0, 1300.0, 25.0)
 plot(result)
 ```
 
-The recipe filters converged points, constructs a closed boundary curve from left and right compositions, and fills the two-phase region.
+The recipe filters converged points, constructs a closed boundary curve from left and right compositions, and fills the region between the two boundaries.
 
 | Attribute | Default |
 |-----------|---------|
@@ -129,14 +129,26 @@ See [`plot_phase_diagram`](@ref) and [`plot_gibbs_curve`](@ref) in the [API Refe
 ## Publication-quality output (PythonPlot)
 
 For publication-quality static figures (PDF / PNG via matplotlib), load the
-PythonPlot extension and call [`savefig_publication`](@ref). The output
-format is selected by the file-name extension (`.pdf` and `.png` work out
-of the box).
+PythonPlot extension. The API has **three layers** (L1 / L2 are unexported —
+call them as `OpenCALPHAD.…`; L3 `savefig_publication` is exported):
+
+| Layer | Function | Returns | Use |
+|-------|----------|---------|-----|
+| L3 | `savefig_publication(result, path; ...)` | `path` | save to PDF or PNG in one call (format from the file extension; delegates to L2) |
+| L2 | `OpenCALPHAD.figure_publication(result; ...)` | `(fig, ax)` | a sized figure + axis to tweak before saving |
+| L1 | `OpenCALPHAD.plot_on_axis!(ax, result; ...)` | `ax` | draw onto your own matplotlib axis (compose a subplot grid) |
 
 ```julia
 using OpenCALPHAD, PythonPlot
-PythonPlot.matplotlib.use("Agg")  # required for headless / CI environments
 ```
+
+On a headless machine or in CI (no display), select a non-interactive backend
+before plotting: `PythonPlot.matplotlib.use("Agg")`.
+
+In every layer the `result` argument may be a `GridScanResult` (Gibbs curve),
+a `StepResult` (`kind = :gibbs` or `:phase_fraction`), or a `PhaseDiagramResult`
+(binary phase diagram). The examples below use L3 (`savefig_publication`) for
+each of these; the *Composing subplots* section further down shows L1 / L2.
 
 ### Gibbs energy curve — `GridScanResult`
 
@@ -151,7 +163,7 @@ savefig_publication(grid_result, "gibbs.pdf";
                     show_minimum = true)
 ```
 
-`show_minimum = true` draws a vertical line at the minimum-G composition.
+`show_minimum = true` draws a vertical line at the composition of minimum G.
 
 ### `StepResult` — Gibbs vs axis or phase fractions
 
@@ -175,28 +187,63 @@ fcc = get_phase(db, "FCC_A1")
 pd_result = map_phase_diagram(fcc, db, 800.0, 1300.0, 25.0)
 
 savefig_publication(pd_result, "phase_diagram.pdf";
-                    axis_width_cm = 10.0, axis_height_cm = 7.0)
+                    axis_width_mm = 100.0, axis_height_mm = 70.0)
 ```
 
-Non-converged points are filtered out automatically; the two-phase region
-between the two boundaries is shaded with `fill_color` at `fill_alpha`.
+Points that did not converge are filtered out automatically; the region
+between the two boundaries is shaded with `fill_color` at `fill_alpha`. If no
+point converges, an empty axes with only the axis labels is drawn.
 
-### Common keyword arguments
+### Keyword reference
 
-| Keyword | Default | Meaning |
-|---|---|---|
-| `axis_width_cm`  | `8.0` | Plot area width  in cm |
-| `axis_height_cm` | `6.0` | Plot area height in cm |
-| `title`          | `""`  | Figure title (empty string keeps no title) |
-| `ylims`          | `nothing` | Pass a tuple to override the y-axis limits |
+Keywords are documented on the functions below. The plot keywords for each
+result type (and the label and title precedence) live on `plot_on_axis!`;
+`figure_publication` adds the figure size keywords; `savefig_publication`
+forwards everything:
 
-`PhaseDiagramResult` additionally takes:
+```@docs
+OpenCALPHAD.savefig_publication
+OpenCALPHAD.figure_publication
+OpenCALPHAD.plot_on_axis!
+```
 
-| Keyword | Default | Meaning |
-|---|---|---|
-| `fill_color` | `"lightgray"` | Two-phase region shading color |
-| `fill_alpha` | `0.3`         | Two-phase region shading alpha |
-| `boundary_color` | `"black"` | Boundary line color |
+### Composing subplots with `plot_on_axis!` (L1) / `figure_publication` (L2)
+
+Beyond `savefig_publication` (L3) shown above, the two lower layers let you
+compose and tweak figures (see the layer table at the top of this section).
+
+**L1 — compose multiple results into one figure** (e.g. a 2×2 poster panel).
+You create the figure with matplotlib's `subplots`/`add_subplot` and own the
+`close`:
+
+```julia
+using OpenCALPHAD, PythonPlot
+
+fig = PythonPlot.figure(figsize = (10, 8))
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 1), grid_result)
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 2), step_result; kind = :gibbs)
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 3), step_result; kind = :phase_fraction)
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 4), pd_result)
+fig.savefig("composite.pdf")
+PythonPlot.close(fig)            # caller owns the figure
+```
+
+The plot keyword arguments for each result type are the same as for `savefig_publication`
+(e.g. `title`, `color`, `show_minimum`, `kind`); `plot_on_axis!` returns the
+same `ax` for chaining.
+
+**L2 — adjust before saving:**
+
+```julia
+fig, ax = OpenCALPHAD.figure_publication(grid_result; axis_width_mm = 100.0)
+ax.axvline(0.5; linestyle = "--")     # add your own annotations
+fig.savefig("annotated.pdf")
+PythonPlot.close(fig)
+```
+
+> Note: inside the extension, figures are created with `PythonPlot.figure(...)`
+> (not `subplots()`), but on the **caller** side `subplots()` is fine — you just
+> own the resulting figure and must `close` it yourself.
 
 ### Installing PythonPlot
 

--- a/examples/000_examples.md
+++ b/examples/000_examples.md
@@ -90,6 +90,12 @@ tracked. Run the script locally to regenerate the figures on demand.
 | `621_parameter_optimization.jl` | Fitting R-K coefficients (+ combined figure for JOSS) |
 | `624_magnetic_optimization.jl` | Optimizing magnetic parameters (Tc, beta) |
 
+### 8xx: Composite / showcase figures
+
+| File | Description |
+|------|-------------|
+| `811_composite_publication.jl` | **Publication-quality** 2×2 composite (Gibbs curve / STEP G(T) / phase fractions / phase diagram) via `OpenCALPHAD.plot_on_axis!` subplot composition (PythonPlot 3-layer API) |
+
 ### 9xx: Benchmarks / References
 
 | File | Description |

--- a/examples/101_gibbs_energy_agcu_publication.jl
+++ b/examples/101_gibbs_energy_agcu_publication.jl
@@ -34,11 +34,11 @@ result = scan_composition(fcc, T, db, solver)
 stem = joinpath(@__DIR__, "101_gibbs_energy_agcu_publication")
 
 savefig_publication(result, "$stem.pdf";
-                    axis_width_cm = 8.0, axis_height_cm = 6.0,
+                    axis_width_mm = 80.0, axis_height_mm = 60.0,
                     title = "Ag-Cu FCC Gibbs energy at T = $(Int(T)) K",
                     show_minimum = true)
 savefig_publication(result, "$stem.png";
-                    axis_width_cm = 8.0, axis_height_cm = 6.0,
+                    axis_width_mm = 80.0, axis_height_mm = 60.0,
                     title = "Ag-Cu FCC Gibbs energy at T = $(Int(T)) K",
                     show_minimum = true)
 

--- a/examples/311_step_gm_agcu_publication.jl
+++ b/examples/311_step_gm_agcu_publication.jl
@@ -39,7 +39,7 @@ for kind in (:gibbs, :phase_fraction)
     for ext in ("pdf", "png")
         savefig_publication(step_result, "$(stem)_$(kind)_publication.$(ext)";
                             kind = kind,
-                            axis_width_cm = 8.0, axis_height_cm = 6.0,
+                            axis_width_mm = 80.0, axis_height_mm = 60.0,
                             title = "Ag-Cu STEP, x(Cu) = 0.5")
     end
 end

--- a/examples/411_phase_diagram_agcu_publication.jl
+++ b/examples/411_phase_diagram_agcu_publication.jl
@@ -30,10 +30,10 @@ result = map_phase_diagram(fcc, db, 800.0, 1300.0, 25.0)
 stem = joinpath(@__DIR__, "411_phase_diagram_agcu_publication")
 
 savefig_publication(result, "$stem.pdf";
-                    axis_width_cm = 10.0, axis_height_cm = 7.0,
+                    axis_width_mm = 100.0, axis_height_mm = 70.0,
                     title = "Ag-Cu binary phase diagram (FCC miscibility gap)")
 savefig_publication(result, "$stem.png";
-                    axis_width_cm = 10.0, axis_height_cm = 7.0,
+                    axis_width_mm = 100.0, axis_height_mm = 70.0,
                     title = "Ag-Cu binary phase diagram (FCC miscibility gap)")
 
 println("Wrote $stem.pdf and $stem.png")

--- a/examples/811_composite_publication.jl
+++ b/examples/811_composite_publication.jl
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of OpenCALPHAD.jl - Example: composite publication figure via plot_on_axis!
+#
+# Demonstrates the 3-layer PythonPlot API by composing four Ag-Cu result types
+# into a single 2x2 publication panel using OpenCALPHAD.plot_on_axis! (L1):
+#   (1) GridScanResult     - Gibbs energy curve G(x) at 1000 K
+#   (2) StepResult         - G(T) along a STEP calculation (kind = :gibbs)
+#   (3) StepResult         - phase fractions vs T   (kind = :phase_fraction)
+#   (4) PhaseDiagramResult - binary phase diagram (FCC miscibility gap)
+#
+# The caller owns the figure (created with PythonPlot.figure / add_subplot) and
+# is responsible for PythonPlot.close. Candidate figure for the JuliaCon 2026
+# Mainz poster (AFVQLM).
+#
+# Usage:
+#   julia --project=. examples/811_composite_publication.jl
+#
+# Output (gitignored):
+#   examples/811_composite_publication.pdf
+#   examples/811_composite_publication.png
+
+using OpenCALPHAD
+using PythonPlot
+
+PythonPlot.matplotlib.use("Agg")
+
+# Larger fonts for poster / publication readability
+let rc = PythonPlot.matplotlib.rcParams
+    rc["axes.titlesize"]  = 17
+    rc["axes.labelsize"]  = 16
+    rc["xtick.labelsize"] = 14
+    rc["ytick.labelsize"] = 14
+    rc["legend.fontsize"] = 14
+end
+
+tdb_path = joinpath(@__DIR__, "..", "reftest", "tdb", "agcu.TDB")
+db = read_tdb(tdb_path)
+fcc = get_phase(db, "FCC_A1")
+
+# Four result types (same Ag-Cu system / ranges as the baseline examples)
+grid_result = scan_composition(fcc, 1000.0, db, GridSearchSolver(n_points = 51))
+step_result = step_temperature(fcc, db, 0.5, 800.0, 1300.0, 25.0)
+pd_result   = map_phase_diagram(fcc, db, 800.0, 1300.0, 25.0)
+
+# Compose a 2x2 grid: caller creates the figure and adds the axes (L1 only
+# mutates each axis). subplots() on the caller side is fine — we own `close`.
+fig = PythonPlot.figure(figsize = (12, 9))
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 1), grid_result;
+                          title = "Gibbs energy at 1000 K", show_minimum = true)
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 2), step_result;
+                          kind = :gibbs, title = "STEP: G vs T")
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 3), step_result;
+                          kind = :phase_fraction, title = "Phase fractions vs T",
+                          legend_loc = "lower center")
+OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 4), pd_result;
+                          title = "Binary phase diagram")
+fig.tight_layout()
+
+stem = joinpath(@__DIR__, "811_composite_publication")
+fig.savefig("$stem.pdf")
+fig.savefig("$stem.png")
+PythonPlot.close(fig)
+
+println("Wrote $stem.pdf and $stem.png")

--- a/ext/OpenCALPHADPythonPlotExt.jl
+++ b/ext/OpenCALPHADPythonPlotExt.jl
@@ -12,10 +12,28 @@ module OpenCALPHADPythonPlotExt
 using OpenCALPHAD
 import OpenCALPHAD: GridScanResult, StepResult, PhaseDiagramResult,
                     temperatures, gibbs_energies, phase_fractions,
-                    savefig_publication
+                    savefig_publication, plot_on_axis!, figure_publication
 import PythonPlot
 
-const CM_PER_INCH = 2.54
+const MM_PER_INCH = 25.4
+
+# Resolve an axis dimension in mm from the mm keyword (canonical) and the
+# deprecated cm alias. The mm keyword always takes precedence; the cm alias
+# emits a deprecation warning, and is ignored when the mm form is also given.
+function _resolve_dim_mm(mm, cm, default, name)
+    if cm !== nothing
+        if mm !== nothing
+            Base.depwarn("axis_$(name)_cm is deprecated and ignored because " *
+                         "axis_$(name)_mm was also given; use axis_$(name)_mm only",
+                         :figure_publication)
+            return mm
+        end
+        Base.depwarn("axis_$(name)_cm is deprecated; use axis_$(name)_mm (mm = 10 × cm)",
+                     :figure_publication)
+        return 10.0 * cm
+    end
+    return mm === nothing ? default : mm
+end
 
 # axis_variable -> default xlabel mapping for StepResult
 const AXIS_LABEL = Dict(
@@ -25,46 +43,47 @@ const AXIS_LABEL = Dict(
 )
 
 """
-    _layout_axes(axis_width_cm, axis_height_cm, n;
-                 margin_left_cm = 3.0, margin_right_cm = 0.3,
-                 margin_bottom_cm = 1.5, margin_top_cm = 0.8,
-                 hgap_cm = 1.8, vgap_cm = 1.5,
+    _layout_axes(axis_width_mm, axis_height_mm, n;
+                 margin_left_mm = 30.0, margin_right_mm = 3.0,
+                 margin_bottom_mm = 15.0, margin_top_mm = 8.0,
+                 hgap_mm = 18.0, vgap_mm = 15.0,
                  nrows = 1, ncols = 1)
 
-Compute figure size (inches) and axes positions from axis dimensions and layout.
+Compute figure size (inches) and axes positions from axis dimensions (in mm)
+and layout.
 
-`margin_left_cm = 3.0` (widened from BT/PX default 2.0) accommodates OC's 4-5 digit
-G [J/mol] tick labels plus the y-axis label.
+`margin_left_mm = 30.0` (widened from BT/PX default 20.0) accommodates OC's
+4-5 digit G [J/mol] tick labels plus the y-axis label.
 """
 function _layout_axes(
-    axis_width_cm,
-    axis_height_cm,
+    axis_width_mm,
+    axis_height_mm,
     n;
-    margin_left_cm   = 3.0,
-    margin_right_cm  = 0.3,
-    margin_bottom_cm = 1.5,
-    margin_top_cm    = 0.8,
-    hgap_cm          = 1.8,
-    vgap_cm          = 1.5,
+    margin_left_mm   = 30.0,
+    margin_right_mm  = 3.0,
+    margin_bottom_mm = 15.0,
+    margin_top_mm    = 8.0,
+    hgap_mm          = 18.0,
+    vgap_mm          = 15.0,
     nrows            = 1,
     ncols            = 1,
 )
-    widths  = axis_width_cm  isa AbstractVector ? axis_width_cm  : fill(axis_width_cm,  ncols)
-    heights = axis_height_cm isa AbstractVector ? axis_height_cm : fill(axis_height_cm, nrows)
+    widths  = axis_width_mm  isa AbstractVector ? axis_width_mm  : fill(axis_width_mm,  ncols)
+    heights = axis_height_mm isa AbstractVector ? axis_height_mm : fill(axis_height_mm, nrows)
 
-    fig_w_cm = margin_left_cm   + sum(widths)  + hgap_cm * (ncols - 1) + margin_right_cm
-    fig_h_cm = margin_bottom_cm + sum(heights) + vgap_cm * (nrows - 1) + margin_top_cm
+    fig_w_mm = margin_left_mm   + sum(widths)  + hgap_mm * (ncols - 1) + margin_right_mm
+    fig_h_mm = margin_bottom_mm + sum(heights) + vgap_mm * (nrows - 1) + margin_top_mm
 
-    fig_w = fig_w_cm / CM_PER_INCH
-    fig_h = fig_h_cm / CM_PER_INCH
+    fig_w = fig_w_mm / MM_PER_INCH
+    fig_h = fig_h_mm / MM_PER_INCH
 
     positions = Vector{NTuple{4,Float64}}()
     for row in 1:nrows
         for col in 1:ncols
-            left   = (margin_left_cm   + sum(widths[1:(col - 1)])    + hgap_cm * (col - 1))     / fig_w_cm
-            bottom = (margin_bottom_cm + sum(heights[(row + 1):end]) + vgap_cm * (nrows - row)) / fig_h_cm
-            w = widths[col]  / fig_w_cm
-            h = heights[row] / fig_h_cm
+            left   = (margin_left_mm   + sum(widths[1:(col - 1)])    + hgap_mm * (col - 1))     / fig_w_mm
+            bottom = (margin_bottom_mm + sum(heights[(row + 1):end]) + vgap_mm * (nrows - row)) / fig_h_mm
+            w = widths[col]  / fig_w_mm
+            h = heights[row] / fig_h_mm
             push!(positions, (left, bottom, w, h))
         end
     end
@@ -206,87 +225,179 @@ function _plot_phase_diagram_on_ax!(
     return ax
 end
 
-# ── savefig_publication dispatch ──
+# ══════════════════════════════════════════════════════════════════════
+# L1 — plot_on_axis!(ax, r; ...) : mutate a user-supplied axis, return ax
+# (thin public wrappers over the existing _plot_*_on_ax! helpers)
+# ══════════════════════════════════════════════════════════════════════
 
 """
-    OpenCALPHAD.savefig_publication(r::GridScanResult, path; kwargs...) -> path
+    plot_on_axis!(ax, r::GridScanResult; kwargs...) -> ax
 
-Render `r` as a publication-quality figure to `path` (PDF/PNG; format chosen by
-extension). Returns `path` for chaining.
+Draw the Gibbs energy curve `G(x)` of a [`GridScanResult`](@ref) onto the
+matplotlib axis you supply and return `ax`, so panels can be composed.
+Requires `using PythonPlot`; not exported (call as `OpenCALPHAD.plot_on_axis!`).
+
+# Arguments
+
+- `ax`: a matplotlib axis (PythonCall `Py`) to draw onto
+- `r::GridScanResult`: the composition scan to plot
+
+# Keywords
+
+- `color="black"`: curve color
+- `linewidth=2.0`: curve line width
+- `linestyle="-"`: curve line style
+- `show_minimum=false`: draw a vertical line at the composition of minimum G
+- `xlabel::AbstractString=""`: x axis label; empty uses `"Composition x"`
+- `ylabel::AbstractString=""`: y axis label; empty uses `"G [J/mol]"`
+- `title::AbstractString=""`: title; empty leaves the axes untitled
 """
-function OpenCALPHAD.savefig_publication(
-    r::GridScanResult,
-    path::AbstractString;
-    axis_width_cm = 8.0,
-    axis_height_cm = 6.0,
-    title::AbstractString = "",
-    ylims = nothing,
-    kwargs...,
-)
-    fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1)
-    fig = PythonPlot.figure(figsize = (fig_w, fig_h))
-    ax  = fig.add_axes(collect(positions[1]))
-    _plot_gibbs_curve_on_ax!(ax, r; title = title, kwargs...)
-    isnothing(ylims) || ax.set_ylim(ylims...)
-    fig.savefig(path)
-    PythonPlot.close(fig)
-    return path
-end
+OpenCALPHAD.plot_on_axis!(ax, r::GridScanResult; kwargs...) =
+    _plot_gibbs_curve_on_ax!(ax, r; kwargs...)
 
 """
-    OpenCALPHAD.savefig_publication(r::StepResult, path; kind = :gibbs, kwargs...) -> path
+    plot_on_axis!(ax, r::PhaseDiagramResult; kwargs...) -> ax
 
-Render a `StepResult` to `path`. `kind = :gibbs` plots `G(axis)`, `kind = :phase_fraction`
-plots phase fractions vs. axis. Other `kind` values raise `ArgumentError`.
+Draw a binary phase diagram of a [`PhaseDiagramResult`](@ref) onto `ax` and
+return `ax`; the region between the two boundaries is shaded. Points that did
+not converge are skipped, and if none converge an empty labelled axes is drawn.
+Requires `using PythonPlot`; not exported (call as `OpenCALPHAD.plot_on_axis!`).
+
+# Arguments
+
+- `ax`: a matplotlib axis (PythonCall `Py`) to draw onto
+- `r::PhaseDiagramResult`: the mapped phase boundaries to plot
+
+# Keywords
+
+- `boundary_color="black"`: boundary line color
+- `linewidth=2.0`: boundary line width
+- `fill_color="lightgray"`: shading color of the region between the boundaries
+- `fill_alpha=0.3`: shading opacity
+- `xlabel::AbstractString=""`: x axis label; empty uses `"Composition x"`
+- `ylabel::AbstractString=""`: y axis label; empty uses `"T [K]"`
+- `title::AbstractString=""`: title; empty leaves the axes untitled
 """
-function OpenCALPHAD.savefig_publication(
-    r::StepResult,
-    path::AbstractString;
-    kind::Symbol = :gibbs,
-    axis_width_cm = 8.0,
-    axis_height_cm = 6.0,
-    title::AbstractString = "",
-    ylims = nothing,
-    kwargs...,
-)
-    fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1)
-    fig = PythonPlot.figure(figsize = (fig_w, fig_h))
-    ax  = fig.add_axes(collect(positions[1]))
+OpenCALPHAD.plot_on_axis!(ax, r::PhaseDiagramResult; kwargs...) =
+    _plot_phase_diagram_on_ax!(ax, r; kwargs...)
+
+"""
+    plot_on_axis!(ax, r::StepResult; kind=:gibbs, kwargs...) -> ax
+
+Draw a [`StepResult`](@ref) onto `ax` and return `ax`. Requires
+`using PythonPlot`; not exported (call as `OpenCALPHAD.plot_on_axis!`).
+
+# Arguments
+
+- `ax`: a matplotlib axis (PythonCall `Py`) to draw onto
+- `r::StepResult`: the STEP calculation to plot
+
+# Keywords
+
+- `kind::Symbol=:gibbs`: `:gibbs` plots `G` against the axis variable;
+    `:phase_fraction` plots the two phase fractions (forcing `ylim=(0,1)` with a
+    legend). Any other value raises `ArgumentError`.
+- `color`, `linewidth=2.0`, `linestyle="-"`: curve style when `kind=:gibbs`
+- `color1="C0"`, `color2="C1"`: per phase colors when `kind=:phase_fraction`
+- `legend_loc="center right"`: legend position when `kind=:phase_fraction`
+- `xlabel::AbstractString=""`: x axis label; empty uses the axis variable label
+- `ylabel::AbstractString=""`: y axis label; empty uses `"G [J/mol]"` or
+    `"Phase fraction"`
+- `title::AbstractString=""`: title; empty leaves the axes untitled
+"""
+function OpenCALPHAD.plot_on_axis!(ax, r::StepResult; kind::Symbol = :gibbs, kwargs...)
     if kind === :gibbs
-        _plot_step_gibbs_on_ax!(ax, r; title = title, kwargs...)
+        _plot_step_gibbs_on_ax!(ax, r; kwargs...)
     elseif kind === :phase_fraction
-        _plot_step_phase_fraction_on_ax!(ax, r; title = title, kwargs...)
+        _plot_step_phase_fraction_on_ax!(ax, r; kwargs...)
     else
-        PythonPlot.close(fig)
         throw(ArgumentError("unknown kind=$(kind); expected :gibbs or :phase_fraction"))
     end
-    isnothing(ylims) || ax.set_ylim(ylims...)
-    fig.savefig(path)
-    PythonPlot.close(fig)
-    return path
+    return ax
 end
 
-"""
-    OpenCALPHAD.savefig_publication(r::PhaseDiagramResult, path; kwargs...) -> path
+# ══════════════════════════════════════════════════════════════════════
+# L2 — figure_publication(r; ...) : create (fig, ax), single axis
+# ══════════════════════════════════════════════════════════════════════
 
-Render a `PhaseDiagramResult` (binary phase diagram with shaded two-phase region).
 """
-function OpenCALPHAD.savefig_publication(
-    r::PhaseDiagramResult,
-    path::AbstractString;
-    axis_width_cm = 8.0,
-    axis_height_cm = 6.0,
-    title::AbstractString = "",
+    figure_publication(r; axis_width_mm=80.0, axis_height_mm=60.0, ylims=nothing, kwargs...) -> (fig, ax)
+
+Create a publication matplotlib figure and a single axis for `r`, draw it via
+[`plot_on_axis!`](@ref), and return `(fig, ax)` so you can tweak it before
+saving. The caller owns the figure and must call `PythonPlot.close(fig)`.
+Requires `using PythonPlot`; not exported (call as `OpenCALPHAD.figure_publication`).
+
+# Arguments
+
+- `r`: a `GridScanResult`, `StepResult`, or `PhaseDiagramResult`
+
+# Keywords
+
+- `axis_width_mm=80.0`: plotting area width in mm
+- `axis_height_mm=60.0`: plotting area height in mm
+- `axis_width_cm`, `axis_height_cm`: deprecated aliases (1 cm = 10 mm). The mm
+    form takes precedence; the cm form warns and is ignored if both are given
+- `ylims=nothing`: pass a tuple to override the y axis limits
+- `kwargs...`: forwarded to [`plot_on_axis!`](@ref)
+"""
+function OpenCALPHAD.figure_publication(
+    r::Union{GridScanResult,StepResult,PhaseDiagramResult};
+    axis_width_mm = nothing,
+    axis_height_mm = nothing,
+    axis_width_cm = nothing,
+    axis_height_cm = nothing,
     ylims = nothing,
     kwargs...,
 )
-    fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1)
+    w_mm = _resolve_dim_mm(axis_width_mm, axis_width_cm, 80.0, "width")
+    h_mm = _resolve_dim_mm(axis_height_mm, axis_height_cm, 60.0, "height")
+    fig_w, fig_h, positions = _layout_axes(w_mm, h_mm, 1)
     fig = PythonPlot.figure(figsize = (fig_w, fig_h))
-    ax  = fig.add_axes(collect(positions[1]))
-    _plot_phase_diagram_on_ax!(ax, r; title = title, kwargs...)
-    isnothing(ylims) || ax.set_ylim(ylims...)
-    fig.savefig(path)
-    PythonPlot.close(fig)
+    try
+        ax = fig.add_axes(collect(positions[1]))
+        plot_on_axis!(ax, r; kwargs...)
+        isnothing(ylims) || ax.set_ylim(ylims...)
+        return fig, ax
+    catch
+        PythonPlot.close(fig)
+        rethrow()
+    end
+end
+
+# ══════════════════════════════════════════════════════════════════════
+# L3 — savefig_publication(r, path; ...) : L2 + savefig + close
+# ══════════════════════════════════════════════════════════════════════
+
+"""
+    savefig_publication(r, path; kwargs...) -> path
+
+Render `r` to `path` and return `path`; the output format follows the file
+extension (`.pdf` or `.png`). This is the convenience entry point (the only
+exported layer): it delegates to [`figure_publication`](@ref) and closes the
+figure for you. Requires `using PythonPlot`.
+
+# Arguments
+
+- `r`: a `GridScanResult`, `StepResult`, or `PhaseDiagramResult`
+- `path::AbstractString`: output file; the extension selects PDF or PNG
+
+# Keywords
+
+- `kwargs...`: forwarded to [`figure_publication`](@ref) (and onward to
+    [`plot_on_axis!`](@ref))
+"""
+function OpenCALPHAD.savefig_publication(
+    r::Union{GridScanResult,StepResult,PhaseDiagramResult},
+    path::AbstractString;
+    kwargs...,
+)
+    fig, _ = figure_publication(r; kwargs...)
+    try
+        fig.savefig(path)
+    finally
+        PythonPlot.close(fig)
+    end
     return path
 end
 

--- a/src/Plotting/fallbacks.jl
+++ b/src/Plotting/fallbacks.jl
@@ -8,3 +8,15 @@ function savefig_publication(args...; kwargs...)
         "savefig_publication requires PythonPlot.jl. Run `using PythonPlot` first."
     ))
 end
+
+function plot_on_axis!(args...; kwargs...)
+    throw(ArgumentError(
+        "plot_on_axis! requires PythonPlot.jl. Run `using PythonPlot` first."
+    ))
+end
+
+function figure_publication(args...; kwargs...)
+    throw(ArgumentError(
+        "figure_publication requires PythonPlot.jl. Run `using PythonPlot` first."
+    ))
+end

--- a/src/Plotting/recipes.jl
+++ b/src/Plotting/recipes.jl
@@ -20,9 +20,9 @@ Plot a Gibbs energy curve. Requires `using Plots`.
 """
 function plot_gibbs_curve end
 
-"""
-    savefig_publication(result, filename; kwargs...)
-
-Save a publication-quality figure. Requires `using PythonPlot`.
-"""
+# PythonPlot extension API (3-layer). Implemented — with their authoritative,
+# per-method docstrings — in ext/OpenCALPHADPythonPlotExt.jl. The extension
+# module is added to Documenter's `modules` so `@docs` renders those docstrings.
 function savefig_publication end
+function plot_on_axis! end
+function figure_publication end

--- a/test/test_publication.jl
+++ b/test/test_publication.jl
@@ -9,6 +9,9 @@ using PythonPlot
 # Force non-interactive backend on CI
 PythonPlot.matplotlib.use("Agg")
 
+# Read a matplotlib title back as a Julia string (robust to Py wrapping)
+_title(ax) = string(ax.get_title())
+
 @testset "savefig_publication (PythonPlot)" begin
     # ── Fixtures ──
     tdb_path = joinpath(dirname(@__DIR__), "reftest", "tdb", "agcu.TDB")
@@ -68,13 +71,30 @@ PythonPlot.matplotlib.use("Agg")
         end
     end
 
-    @testset "axis_width_cm / axis_height_cm custom kwargs" begin
+    @testset "axis_width_mm / axis_height_mm custom kwargs" begin
         mktempdir() do tmp
             path = joinpath(tmp, "custom.pdf")
+            savefig_publication(grid_result, path;
+                                axis_width_mm = 100.0, axis_height_mm = 50.0)
+            @test isfile(path)
+        end
+    end
+
+    @testset "axis_*_cm deprecated alias still works" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "cm.pdf")
             savefig_publication(grid_result, path;
                                 axis_width_cm = 10.0, axis_height_cm = 5.0)
             @test isfile(path)
         end
+    end
+
+    @testset "mm takes precedence when both mm and cm given" begin
+        # mm wins; the cm alias is ignored (with a deprecation warning), no error
+        fig, ax = OpenCALPHAD.figure_publication(
+            grid_result; axis_width_mm = 80.0, axis_width_cm = 8.0)
+        @test fig isa PythonPlot.Figure
+        PythonPlot.close(fig)
     end
 
     @testset "title kwarg" begin
@@ -94,7 +114,83 @@ PythonPlot.matplotlib.use("Agg")
     end
 
     @testset "kind unknown value throws ArgumentError" begin
+        # After the 3-layer refactor this ArgumentError originates in
+        # plot_on_axis!(::StepResult); behavior unchanged for savefig callers.
         @test_throws ArgumentError savefig_publication(
             step_result, joinpath(tempdir(), "x.pdf"); kind = :bogus)
+    end
+
+    # ─────────────────── L1: plot_on_axis! (subplot composition) ───────────────────
+    @testset "L1 plot_on_axis! returns ax (4 result paths)" begin
+        for (r, kw) in ((grid_result, (;)),
+                        (step_result, (;)),
+                        (step_result, (kind = :phase_fraction,)),
+                        (pd_result, (;)))
+            fig = PythonPlot.figure()
+            ax = fig.add_subplot()
+            @test OpenCALPHAD.plot_on_axis!(ax, r; kw...) === ax
+            PythonPlot.close(fig)
+        end
+    end
+
+    @testset "L1 2x2 subplot composition smoke" begin
+        mktempdir() do tmp
+            fig = PythonPlot.figure(figsize = (10, 8))
+            OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 1), grid_result)
+            OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 2), step_result; kind = :gibbs)
+            OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 3), step_result; kind = :phase_fraction)
+            OpenCALPHAD.plot_on_axis!(fig.add_subplot(2, 2, 4), pd_result)
+            path = joinpath(tmp, "composite.pdf")
+            fig.savefig(path)
+            PythonPlot.close(fig)
+            @test isfile(path)
+        end
+    end
+
+    @testset "L1 plot_on_axis!(::StepResult; kind=:bogus) throws" begin
+        fig = PythonPlot.figure()
+        ax = fig.add_subplot()
+        @test_throws ArgumentError OpenCALPHAD.plot_on_axis!(ax, step_result; kind = :bogus)
+        PythonPlot.close(fig)
+    end
+
+    @testset "L1 title resolution (2-stage: empty -> no title, kwarg -> override)" begin
+        fig = PythonPlot.figure(); ax = fig.add_subplot()
+        OpenCALPHAD.plot_on_axis!(ax, grid_result)
+        @test isempty(_title(ax))                       # no PF-style default title
+        PythonPlot.close(fig)
+        fig = PythonPlot.figure(); ax = fig.add_subplot()
+        OpenCALPHAD.plot_on_axis!(ax, grid_result; title = "Ag-Cu")
+        @test occursin("Ag-Cu", _title(ax))
+        PythonPlot.close(fig)
+    end
+
+    # ─────────────────── L2: figure_publication ───────────────────
+    @testset "L2 figure_publication returns (fig, ax) for all 3 result types" begin
+        for r in (grid_result, step_result, pd_result)
+            fig, ax = OpenCALPHAD.figure_publication(r)
+            @test fig isa PythonPlot.Figure
+            PythonPlot.close(fig)
+        end
+    end
+
+    @testset "L2 StepResult kind flows through to L1" begin
+        fig, ax = OpenCALPHAD.figure_publication(step_result; kind = :phase_fraction)
+        @test fig isa PythonPlot.Figure
+        PythonPlot.close(fig)
+        @test_throws ArgumentError OpenCALPHAD.figure_publication(step_result; kind = :bogus)
+    end
+
+    @testset "L2 ylims routing" begin
+        fig, ax = OpenCALPHAD.figure_publication(grid_result; ylims = (-60000.0, 0.0))
+        @test fig isa PythonPlot.Figure
+        @test occursin("-60000", string(ax.get_ylim()))
+        PythonPlot.close(fig)
+    end
+
+    # ─────────────────── fallback (bad type → src ArgumentError) ───────────────────
+    @testset "fallback: unsupported type throws ArgumentError" begin
+        @test_throws ArgumentError OpenCALPHAD.plot_on_axis!(nothing, "not a result")
+        @test_throws ArgumentError OpenCALPHAD.figure_publication("not a result")
     end
 end


### PR DESCRIPTION
Adds the two lower plotting layers over `savefig_publication`, all dispatching
on `GridScanResult` / `StepResult` / `PhaseDiagramResult`:

- `plot_on_axis!(ax, result; ...)` — draw onto a user-supplied axis; returns `ax`
- `figure_publication(result; ...)` — return `(fig, ax)` to tweak before saving
- `savefig_publication` now delegates to `figure_publication` (unchanged behavior)

L1/L2 are unexported. Axis sizes move to mm (`axis_width_mm` / `axis_height_mm`);
cm keywords remain as deprecated aliases (mm wins if both given). Docs render the
ext docstrings via `@docs`; adds `examples/811_composite_publication.jl`.

Additive (v0.2.1). Tests 140 -> 159.
