### PR TITLE
Add composition-based gibbs_energy for phase field coupling

### DIFF
--- a/src/Calculations/phase_field.jl
+++ b/src/Calculations/phase_field.jl
@@ -51,6 +51,39 @@ function driving_force(
 end
 
 """
+    gibbs_energy(phase, T, x, db; P=1e5) -> Float64
+
+Molar Gibbs energy of a binary phase at mole fraction `x`.
+
+Composition based companion to [`calculate_gibbs_energy`](@ref) (which takes
+site fractions), matching the `x` based phase field coupling API
+(`driving_force`, `chemical_potential`, `diffusion_potential`).
+
+# Arguments
+
+  - `phase::Phase`: Phase object
+  - `T::Real`: Temperature [K]
+  - `x::Real`: Mole fraction of second component (0 to 1)
+  - `db::Database`: Database
+  - `P::Real`: Pressure [Pa]
+
+# Returns
+
+  - G [J/mol]
+
+# Example
+
+```julia
+fcc = get_phase(db, "FCC_A1")
+G = gibbs_energy(fcc, 1000.0, 0.3, db)
+```
+"""
+function gibbs_energy(phase::Phase, T::Real, x::Real, db::Database; P::Real = 1e5)
+    y = _composition_to_site_fractions(phase, x)
+    return calculate_gibbs_energy(phase, T, y, db; P = P)
+end
+
+"""
     chemical_potential(phase, T, x, db; P=1e5) -> Tuple{Float64, Float64}
 
 Calculate chemical potentials of both components.

--- a/src/OpenCALPHAD.jl
+++ b/src/OpenCALPHAD.jl
@@ -137,7 +137,7 @@ export get_julia_endmembers, get_julia_interactions
 export validate_ad_compatibility
 
 # Exports - Phase Field integration
-export driving_force, chemical_potential, diffusion_potential
+export driving_force, gibbs_energy, chemical_potential, diffusion_potential
 export phase_field_params
 
 # Exports - Version info

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -585,6 +585,20 @@ using Aqua
         end
     end
 
+    @testset "Phase field coupling: gibbs_energy" begin
+        agcu_path = joinpath(@__DIR__, "..", "reftest", "tdb", "agcu.TDB")
+        db = read_tdb(agcu_path)
+        fcc = get_phase(db, "FCC_A1")
+        liquid = get_phase(db, "LIQUID")
+        T, x = 1000.0, 0.3
+
+        @test isfinite(gibbs_energy(fcc, T, x, db))
+        @test isfinite(gibbs_energy(liquid, T, x, db))
+        # gibbs_energy must agree with the driving_force path (same internals)
+        ΔG = driving_force(db, T, x, "FCC_A1", "LIQUID")
+        @test gibbs_energy(fcc, T, x, db) - gibbs_energy(liquid, T, x, db) ≈ ΔG
+    end
+
     # Multi-component support tests (Cr-Mo from steel1.TDB)
     include("multicomponent.jl")
 


### PR DESCRIPTION
Closes #31. See the commit for details.

- `Pkg.test()`: 162 PASS (new "Phase field coupling: gibbs_energy" testset checks the value is finite and consistent with `driving_force`)