### PR TITLE
Release v0.2.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-0071-2396"
 license: GPL-3.0-or-later
 repository-code: "https://github.com/hsugawa8651/OpenCALPHAD.jl"
-version: 0.2.1
+version: 0.2.2
 date-released: 2026-05-31
 doi: 10.5281/zenodo.18670627
 references:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenCALPHAD"
 uuid = "f22b17f6-ccb9-4067-ab50-5d8cfb3cb77d"
 authors = ["Hiroharu Sugawara <hsugawa@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"


### PR DESCRIPTION
Bump version 0.2.1 -> 0.2.2. Adds composition-based `gibbs_energy` (#32) to the phase field coupling API.

Registration follows after merge via a JuliaRegistrator comment.